### PR TITLE
Chore: 글로벌css 추가

### DIFF
--- a/src/pages/Test.tsx
+++ b/src/pages/Test.tsx
@@ -1,5 +1,10 @@
 const Test = () => {
-  return <div className="h-[240px] w-full bg-sky-400 text-xl text-white">cicd 테스트 최종.</div>;
+  return (
+    <div className="h-full w-full bg-sky-400 text-xl text-white">
+      cicd 테스트 최종.
+      <p>글로벌 css 테스트</p>
+    </div>
+  );
 };
 
 export default Test;

--- a/src/shared/styles/global.css
+++ b/src/shared/styles/global.css
@@ -1,3 +1,54 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  * {
+    font-family: 'Pretendard Variable', Pretendard, sans-serif;
+  }
+  html {
+    width: 393px;
+    margin: 0 auto;
+    min-height: 100vh;
+    background-color: #f8f8f8;
+  }
+  body {
+    overflow-x: hidden;
+  }
+  body {
+    -ms-overflow-style: none;
+  }
+  html,
+  body,
+  #root {
+    height: 100%;
+  }
+  ::-webkit-scrollbar {
+    display: none;
+  }
+  button {
+    margin: 0;
+    padding: 0;
+    border: none;
+    background-color: transparent;
+    cursor: pointer;
+    &:disabled {
+      cursor: not-allowed;
+    }
+  }
+  input {
+    border: none;
+    :focus {
+      outline: none;
+    }
+  }
+  a {
+    color: #fff;
+    text-decoration: none;
+    outline: none;
+  }
+  a:hover,
+  a:active {
+    text-decoration: none;
+  }
+}


### PR DESCRIPTION
## 📝 작업 내용

- global.css 코드에 초기 css 설정 코드 작성하였습니다.

<br/>

## 📢 PR Point

- margin 0 auto 로 가운데다 두고 작업할 수 있도록 하였습니다.
- width는 393px 로 고정했습니다.
- height의 경우 뷰포트의 크기 100%로 채우기 위해(반응형 good) min-height : 100vh 코드를 사용하여 뷰포트 크기에 맞게 높이가 꽉차도록 하였습니다.

<br/>

## 이미지 첨부
![image](https://github.com/user-attachments/assets/f7339c85-39be-482c-b487-a65282f124de)


<br/>

## 🔧 다음 할 일

- 다음 할 일을 적어주세요

<br/> 