### PR TITLE
Feat: 홈화면 대표 가게 api 연동 및 콜키지스코어 렌더링 구현

### DIFF
--- a/src/pages/home/CorkStores.tsx
+++ b/src/pages/home/CorkStores.tsx
@@ -15,8 +15,8 @@ const CorkStores = () => {
         <div></div>
         <SelectBox value={range} setRange={setRange} />
       </div>
-      {/* <CorkScoreList range={range} /> */}
-      <CorkScoreList />
+      <CorkScoreList range={range} />
+      {/* <CorkScoreList /> */}
       <RegionSearchBar />
     </div>
   );

--- a/src/pages/home/StoreList.tsx
+++ b/src/pages/home/StoreList.tsx
@@ -13,6 +13,10 @@ import keepIcon from '../../shared/assets/keep.svg';
 import { type Corkage, fetchCorkageList } from '@/shared/apis/restaurant/corkageApi';
 import { fetchTipList, type TipList } from '@/shared/apis/tip/tipListApi';
 import type { Selected } from '@/shared/components/home/type';
+import {
+  fetchHomeRestaurant,
+  type HomeRestaruantInfo,
+} from '@/shared/apis/restaurant/homeRestaurantApi';
 
 const StoreList = () => {
   const [storeSelected, setStoreSelected] = useState<boolean>(false);
@@ -71,24 +75,55 @@ const StoreList = () => {
     fetchTipData();
   }, []);
 
+  //홈화면 가게 정보
+  const [signature, setSignature] = useState<HomeRestaruantInfo>();
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await fetchHomeRestaurant();
+        if (!cancelled) setSignature(data);
+        console.log('홈 화면 식당 정보 조회 성공');
+      } catch (e) {
+        console.error(e);
+        console.log('홈 화면 식당 정보 조회 실패');
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  const goStore = () => {
+    console.log('홈 대표 가게 상세 정보 페이지 이동');
+    navigate(`/detailInfo/${signature?.restaurantId}`);
+  };
+
   //tip 카테고리 상태
   const [selected, setSelected] = useState<Selected>('ALL');
   const filtered =
     selected === 'ALL' ? tiplist : tiplist?.filter((t) => t.tipCategory === selected);
 
   return (
-    //Todo: TopBar fixed 주기
-    //SearchedStore.tsx, SearchedStoreList.tsx 안쓸듯?
     <div className="flex flex-col items-center">
       <TopBar searchDisabled={false} />
       <div className="relative mb-4">
-        <img src="https://placehold.co/361x200" className="rounded-lg" />
-        <div className="absolute left-4 top-4">
+        {/* <img
+          src="http://t1.kakaocdn.net/fiy_reboot/place/C1B6E3FC902945369E993185518384E6"
+          className="h-[200px] w-[361px] cursor-pointer rounded-lg object-cover"
+          onClick={goStore}
+        /> */}
+        <img
+          onClick={goStore}
+          src={signature?.imageUrl ? signature.imageUrl : 'https://placehold.co/361x200'}
+          className="h-[200px] w-[361px] cursor-pointer rounded-lg object-cover"
+        />
+        <div className="pointer-events-none absolute inset-0 rounded-lg bg-black/40" />
+        <div className="absolute left-4 top-4 z-10">
           <div className="flex flex-col gap-2">
-            <div className="title">성수 누메로도스</div>
+            <div className="title">{signature?.restaurantName}</div>
             <div className="flex gap-2">
               <img src={keepIcon} />
-              <div className="title">198</div>
+              <div className="title">{signature?.bookmarkCount}</div>
             </div>
           </div>
         </div>

--- a/src/shared/apis/bookmark/restaurantApi.ts
+++ b/src/shared/apis/bookmark/restaurantApi.ts
@@ -1,0 +1,24 @@
+import apiClient from '../apiClient';
+
+export interface HotRestaurant {
+  restaurantId: number; //1,
+  restaurantName: string; //"서북면옥",
+  address: string; //"서울특별시 광진구 자양로 199-1 (구의동)",
+  bookmarkCount: number; //5,
+  openingHours: string; //null,
+  imageUrl: string; //null
+}
+
+export interface HotStoreResponse {
+  success: boolean;
+  code: number;
+  message: string;
+  data: HotRestaurant[];
+}
+
+export const fetchHotRestaurant = async (): Promise<HotRestaurant[]> => {
+  const response = await apiClient.get<HotStoreResponse>(`/restaurants/hot`);
+  console.log(response);
+
+  return response.data.data;
+};

--- a/src/shared/apis/restaurant/corkageScoreApi.ts
+++ b/src/shared/apis/restaurant/corkageScoreApi.ts
@@ -3,10 +3,9 @@ import apiClient from '../apiClient';
 export interface CorkageScoreParams {
   range?: 1 | 3 | 7 | 30;
 }
-
 export interface CorkageScore {
   reviewId: number; //1,
-  name: string; //"엔비 햄버거",
+  restaurantName: string; //"엔비 햄버거",
   userName: string; //"니콜라 테슬라",
   content: string; //"몰트향과 완벽하게 어우러지는 조화로운 페어링입니다.",
   rating: number; //5,
@@ -26,23 +25,28 @@ export const fetchCorkageScore = async ({ range = 1 }: CorkageScoreParams = {}):
   CorkageScore[]
 > => {
   //기본값1, 허용값만 통과시킴
-  const fixed = ([1, 3, 7, 30] as const).includes(range) ? range : 1;
-  //보정된 값을 문자열로 바꾸어 쿼리스트링 생성
+  const fixed = ([1, 3, 7, 30] as const).includes(range) ? range : 1; //보정된 값을 문자열로 바꾸어 쿼리스트링 생성
   const queryString = new URLSearchParams({ range: String(fixed) }).toString();
-
-  //   const searchParams = new URLSearchParams();
-  //   if (params.range) searchParams.append('range', String(params.range));
-  //   else {
-  //     {
-  //       params.range = 1;
-  //     }
-  //     searchParams.append('range', String(params.range));
-  //   }
-
+  // const searchParams = new URLSearchParams();
+  // if (params.range) searchParams.append('range', String(params.range));
+  // else {
+  //   { params.range = 1; } searchParams.append('range', String(params.range));
+  // }
   const response = await apiClient.get<CorkageScoreResponse>(
-    `/reviews/corkageScore?${queryString}`
+    `/reviews/corkageScore?${queryString} `
   );
   console.log(response);
-
   return response.data.data;
 };
+
+// export const fetchCorkageScore = async ({ range = 1 }: CorkageScoreParams = {}): Promise<
+//   CorkageScore[]
+// > => {
+//   const fixed = ([1, 3, 7, 30] as const).includes(range) ? range : 1;
+
+//   const { data } = await apiClient.get<CorkageScoreResponse>('/reviews/corkageScore', {
+//     params: { range: fixed },
+//   });
+
+//   return data.data;
+// };

--- a/src/shared/apis/restaurant/homeRestaurantApi.ts
+++ b/src/shared/apis/restaurant/homeRestaurantApi.ts
@@ -1,0 +1,21 @@
+import apiClient from '../apiClient';
+
+export interface HomeRestaruantInfo {
+  restaurantId: number; //1,
+  restaurantName: string; //"서북면옥",
+  bookmarkCount: number; //10,
+  imageUrl: string;
+}
+export interface HomeRestaruantResponse {
+  success: boolean;
+  code: number;
+  message: string;
+  data: HomeRestaruantInfo;
+}
+
+export const fetchHomeRestaurant = async (): Promise<HomeRestaruantInfo> => {
+  const response = await apiClient.get<HomeRestaruantResponse>('/restaurants/home');
+  if (!response?.data?.data) throw new Error('빈 응답입니다.');
+  else console.log(response);
+  return response.data.data;
+};

--- a/src/shared/components/corkScore/CorkScore.tsx
+++ b/src/shared/components/corkScore/CorkScore.tsx
@@ -1,19 +1,20 @@
 // import React from 'react'
 // import { useNavigate } from 'react-router-dom';
 // import etc from '../../assets/detailPageImgs/etc.svg';
+import type { CorkageScore } from '@/shared/apis/restaurant/corkageScoreApi';
 import star from '../../assets/rating.svg';
 import OptionMenu from './OptionMenu';
 
-interface corkScoreProps {
-  name: string;
-  keep: number;
-  rating: number;
-  review: string;
-  id: string;
-  date: string;
-}
-
-const CorkScore = ({ name, keep, rating, review, id, date }: corkScoreProps) => {
+const CorkScore = ({
+  reviewId,
+  restaurantName,
+  userName,
+  content,
+  rating,
+  createdAt,
+  imageUrl,
+  bookmarkCount,
+}: CorkageScore) => {
   //   const navigate = useNavigate();
   // const goStore = () => {
   //   console.log('가게 상세 정보 페이지 이동');
@@ -23,10 +24,10 @@ const CorkScore = ({ name, keep, rating, review, id, date }: corkScoreProps) => 
     <div className="flex h-[144px] w-[357px] justify-between rounded-2xl bg-[#F3F3F6]">
       <div className="mb-4 ml-4 mt-4 flex w-[210px] flex-col pr-2">
         <div className="flex justify-between">
-          <div className="text-[20px] font-bold">{name}</div>
+          <div className="text-[20px] font-bold">{restaurantName}</div>
           <div className="flex items-center justify-center">
             <button className="mr-2 h-[25px] w-[46px] rounded-xl bg-[#DACBB64D] text-[10px]">
-              저장 {keep}
+              저장 {bookmarkCount}
             </button>
             {/* <img className="h-[10px] w-[2px]" src={etc} /> */}
             <OptionMenu />
@@ -36,13 +37,17 @@ const CorkScore = ({ name, keep, rating, review, id, date }: corkScoreProps) => 
           <img className="h-[15px] w-[96px]" src={star} />
           <div className="text-[16px]">{rating}</div>
         </div>
-        <div className="mb-[2px] line-clamp-2 w-[180px] text-[14px]">{review}</div>
+        <div className="mb-[2px] line-clamp-2 w-[180px] text-[14px]">{content}</div>
         <div className="flex gap-2 text-[10px]">
-          <div>{id}</div>
-          <div>{date}</div>
+          <div>{userName}</div>
+          <div>{createdAt}</div>
         </div>
       </div>
-      <img src="https://placehold.co/128X144" className="rounded-r-2xl" />
+      <img
+        key={reviewId}
+        src={imageUrl ? imageUrl : 'https://placehold.co/128X144'}
+        className="h-[144px] w-[128px] rounded-r-2xl"
+      />
     </div>
   );
 };

--- a/src/shared/components/corkScore/CorkScoreList.tsx
+++ b/src/shared/components/corkScore/CorkScoreList.tsx
@@ -1,73 +1,55 @@
 // import React from 'react'
 // import { fetchCorkageList } from '@/shared/apis/restaurant/corkageApi';
 import CorkScore from './CorkScore';
-// import type { DayRange } from './types';
-// import { useEffect, useState } from 'react';
-// import { fetchCorkageScore, type CorkageScore } from '@/shared/apis/restaurant/corkageScoreApi';
+import type { DayRange } from './types';
+import { useEffect, useState } from 'react';
+import { fetchCorkageScore, type CorkageScore } from '@/shared/apis/restaurant/corkageScoreApi';
 
-// type Props = { range: DayRange };
+const CorkScoreList = ({ range }: { range: DayRange }) => {
+  const [corkages, setCorkages] = useState<CorkageScore[]>();
 
-// const CorkScoreList = ({ range }: Props) => {
-const CorkScoreList = () => {
-  // const [corkage, setCorkage] = useState<CorkageScore[]>();
+  useEffect(() => {
+    let cancelled = false;
 
-  // useEffect(() => {
-  //   const fetchData = async () => {
-  //     try {
-  //       const res = await fetchCorkageScore();
-  //       console.log(res);
-  //       setCorkage(res);
-  //     } catch (err) {
-  //       console.error('API  호출 실패');
-  //     }
-  //   };
-  //   fetchData();
-  // }, []);
+    (async () => {
+      try {
+        const res = await fetchCorkageScore({ range });
+        if (!cancelled) {
+          setCorkages(res);
+          console.log('콜키지 스코어 api 호출 성공');
+        }
+      } catch (e) {
+        console.error('API 호출 실패', e);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [range]);
+
+  const visible = corkages;
 
   //여기서 corkage 배열 중 createdAt 시간 계산해서 렌더링 필요
-
   return (
     <div className="mb-[60px] flex flex-col items-center justify-center gap-4">
-      <CorkScore
-        name="엔비 햄버거"
-        keep={27}
-        rating={4.2}
-        review="몰트향과 완벽하게 어우러지는 조화로운 페어링입니다."
-        id="니콜라 테슬라"
-        date="2025.01.01"
-      />
-      <CorkScore
-        name="이가네 양꼬치"
-        keep={83}
-        rating={4.2}
-        review="오랜만에 이가네~~ 양꼬치 커서 넘 조아효.."
-        id="코룽이"
-        date="2025.04.11"
-      />
-      <CorkScore
-        name="신선술집 도원"
-        keep={42}
-        rating={4.2}
-        review="데이트하기 좋아요! 한옥 느낌의 분위기가 좋고 안주 가성비도 좋아요."
-        id="han**"
-        date="2025.05.10"
-      />
-      <CorkScore
-        name="로니로티"
-        keep={27}
-        rating={4.2}
-        review="몰트향과 완벽하게 어우러지는 조화로운 페어링입니다."
-        id="니콜라 테슬라"
-        date="2025.01.01"
-      />
-      <CorkScore
-        name="로니로티"
-        keep={27}
-        rating={4.2}
-        review="몰트향과 완벽하게 어우러지는 조화로운 페어링입니다."
-        id="니콜라 테슬라"
-        date="2025.01.01"
-      />
+      {/* {corkages &&
+        corkages.map((corkage) => { */}
+      {visible &&
+        visible.map((corkage) => {
+          return (
+            <CorkScore
+              reviewId={corkage.reviewId}
+              restaurantName={corkage.restaurantName}
+              userName={corkage.userName}
+              content={corkage.content}
+              rating={corkage.rating}
+              createdAt={corkage.createdAt}
+              imageUrl={corkage.imageUrl}
+              bookmarkCount={corkage.bookmarkCount}
+            />
+          );
+        })}
     </div>
   );
 };

--- a/src/shared/components/corkScore/date.ts
+++ b/src/shared/components/corkScore/date.ts
@@ -1,0 +1,23 @@
+// utils/date.ts
+import type { DayRange } from './types';
+
+export const parseYMDLocal = (ymd: string) => {
+  // "YYYY-MM-DD"를 로컬 타임으로 파싱 (UTC 해석으로 인한 하루 밀림 방지)
+  const [y, m, d] = ymd.split('-').map(Number); //기호 '-' 다 빼고
+  return new Date(y, (m ?? 1) - 1, d ?? 1); //Date 객체로 만들기
+};
+
+export const diffInDaysFromToday = (ymd: string) => {
+  const created = parseYMDLocal(ymd);
+  const now = new Date(); //오늘 날짜 객체로 만들기
+  //날짜를 모두 자정으로 만들어서 날짜 차이 계산
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const startOfCreated = new Date(created.getFullYear(), created.getMonth(), created.getDate());
+  const ms = startOfToday.getTime() - startOfCreated.getTime();
+  return Math.floor(ms / (1000 * 60 * 60 * 24)); // 0=오늘, 1=어제 , 2=2일전
+};
+
+export const isWithinRange = (ymd: string, range: DayRange) => {
+  const d = diffInDaysFromToday(ymd);
+  return d >= 0 && d < range;
+};

--- a/src/shared/components/keep/Review.tsx
+++ b/src/shared/components/keep/Review.tsx
@@ -1,10 +1,27 @@
 // import React from 'react'
-import CorkScore from '../corkScore/CorkScore';
+// import CorkScore from '../corkScore/CorkScore';
 
+//이거 저장한 리뷰임...
 const Review = () => {
   return (
     <div className="flex flex-col items-center justify-center gap-4">
+      <div>저장한 리뷰 list</div>
+      {/* {corkages &&
+        corkages.map((corkage) => {
+          return (
       <CorkScore
+      reviewId={corkage.reviewId}
+        name={corkage.name}
+        userName={corkage.userName}
+        content={corkage.content}
+        rating={corkage.rating}
+        createdAt={corkage.createdAt}
+        imageUrl={corkage.imageUrl}
+        bookmarkCount={corkage.bookmarkCount}
+      />
+          );
+        })} */}
+      {/* <CorkScore
         name="엔비 햄버거"
         keep={27}
         rating={4.2}
@@ -43,7 +60,7 @@ const Review = () => {
         review="몰트향과 완벽하게 어우러지는 조화로운 페어링입니다."
         id="니콜라 테슬라"
         date="2025.01.01"
-      />
+      /> */}
     </div>
   );
 };


### PR DESCRIPTION
## 📝 작업 내용

- 홈 화면 대표 가게 조회 페이지 api를 연동하였습니다.
- 콜키지 스코어 api를 수정하였습니다.
- 콜키지 스코어에서 생성 날짜(createdAt)에 따라 렌더링되도록 기능을 구현하였습니다.

<br/>

## 📢 PR Point

- 

<br/>

## 이미지 첨부
<img width="650" height="821" alt="image" src="https://github.com/user-attachments/assets/9a9f8a60-7419-468c-b529-b160b81e3c71" />
<img width="614" height="1120" alt="image" src="https://github.com/user-attachments/assets/d9a8e707-11be-4c0b-a1dd-d8efd5567d31" />


<br/>

## 🔧 다음 할 일

- 다음 할 일을 적어주세요

<br/> 