### PR TITLE
[Feat] bookmark 모든도메인 연동코드 구현

### DIFF
--- a/src/shared/apis/bookmark/bookmark.api.ts
+++ b/src/shared/apis/bookmark/bookmark.api.ts
@@ -1,0 +1,160 @@
+import apiClient from '../apiClient';
+
+interface ApiResponse {
+  success: boolean;
+  code: number;
+  message: string;
+}
+
+interface BookmarkRequest {
+  targetId: number;
+  targetType: 'REVIEW' | 'TIP' | 'RESTAURANT';
+  groupIds?: number[];
+}
+
+interface CancelBookmarkRequest {
+  targetId: number;
+  targetType: 'REVIEW' | 'TIP';
+}
+
+interface EditGroupRequest {
+  restaurantId: number;
+  groupIds: number[];
+}
+
+interface ReviewBookmarkListResponse extends ApiResponse {
+  data: {
+    bookmarkId: number;
+    reviewId: number;
+    restaurantName: string;
+    bookmarkCount: number;
+    reviewImageUrl: string;
+    rating: number;
+    content: string;
+    userName: string;
+    createdAt: string;
+  }[];
+}
+
+interface TipBookmarkListResponse extends ApiResponse {
+  data: {
+    bookmarkId: number;
+    tipId: number;
+    title: string;
+    tipCategory: string;
+    imageUrl: string;
+    createdAt: string;
+  }[];
+}
+
+interface CreateGroupRequest {
+  name: string;
+  color: string;
+  visibility: 'PUBLIC' | 'PRIVATE';
+}
+
+interface UpdateGroupRequest {
+  name: string;
+  color: string;
+  visibility: 'PUBLIC' | 'PRIVATE';
+}
+
+interface GroupListResponse extends ApiResponse {
+  data: {
+    totalGroupCount: number;
+    groups: {
+      groupId: number;
+      name: string;
+      color: string;
+      visibility: 'PUBLIC' | 'PRIVATE';
+      storeCount: number;
+      createdAt: string;
+      updatedAt: string;
+    }[];
+  };
+}
+
+interface GroupDetailResponse extends ApiResponse {
+  data: {
+    groupName: string;
+    totalCount: number;
+    restaurants: {
+      restaurantId: number;
+      name: string;
+      rating: number;
+      reviewCount: number;
+      openingHoursText: string;
+      imageUrls: string[];
+      corkagePrice: string;
+      corkageOption: string;
+    }[];
+  };
+}
+
+// 저장하기(리뷰/팁/매장) (2차)
+export const createBookmark = async (data: BookmarkRequest): Promise<ApiResponse> => {
+  const response = await apiClient.post<ApiResponse>('/bookmarks', data);
+  return response.data;
+};
+
+// 저장하기 취소 (리뷰/팁)
+export const deleteBookmark = async (data: CancelBookmarkRequest): Promise<ApiResponse> => {
+  const response = await apiClient.delete<ApiResponse>('/bookmarks', { data });
+  return response.data;
+};
+
+// 저장 그룹 편집
+export const editBookmarkGroup = async (data: EditGroupRequest): Promise<ApiResponse> => {
+  const response = await apiClient.put<ApiResponse>('/bookmarks/restaurants', data);
+  return response.data;
+};
+
+// 내가 저장한 리뷰 리스트
+export const getMyReviewBookmarks = async (): Promise<ReviewBookmarkListResponse> => {
+  const response = await apiClient.get<ReviewBookmarkListResponse>('/bookmarks/review');
+  return response.data;
+};
+
+// 내가 저장한 tip 리스트
+export const getMyTipBookmarks = async (): Promise<TipBookmarkListResponse> => {
+  const response = await apiClient.get<TipBookmarkListResponse>('/bookmarks/tip');
+  return response.data;
+};
+
+// 새 그룹 생성
+export const createBookmarkGroup = async (data: CreateGroupRequest): Promise<ApiResponse> => {
+  const response = await apiClient.post<ApiResponse>('/bookmarks/groups', data);
+  return response.data;
+};
+
+// 특정 그룹 정보 수정
+export const updateBookmarkGroup = async (
+  groupId: number,
+  data: UpdateGroupRequest
+): Promise<ApiResponse> => {
+  const response = await apiClient.put<ApiResponse>(`/bookmarks/groups/${groupId}`, data);
+  return response.data;
+};
+
+// 특정 그룹 삭제
+export const deleteBookmarkGroup = async (groupId: number): Promise<ApiResponse> => {
+  const response = await apiClient.delete<ApiResponse>(`/bookmarks/groups/${groupId}`);
+  return response.data;
+};
+
+// 저장 그룹 리스트 조회
+export const getBookmarkGroups = async (): Promise<GroupListResponse> => {
+  const response = await apiClient.get<GroupListResponse>('/bookmarks/groups');
+  return response.data;
+};
+
+// 특정 그룹 내용 조회
+export const getBookmarkGroupDetail = async (
+  groupId: number,
+  sort: 'LATEST' | 'REVIEW_COUNT_DESC' | 'RATING_DESC' = 'LATEST'
+): Promise<GroupDetailResponse> => {
+  const response = await apiClient.get<GroupDetailResponse>(`/bookmarks/groups/${groupId}`, {
+    params: { sort },
+  });
+  return response.data;
+};


### PR DESCRIPTION
## 📝 작업 내용

- 아래 사진의 Bookmark 도메인과 관련된 "모든" 연동 코드를 bookmark.api.ts 파일에 구현해두었습니다. 기존에 사용했던 연동 코드들도 이제는  bookmark.api.ts  파일안에 함수를 이용하면 모두 처리 가능합니다. 다만, 기존에 이미 다른 bookmark api 연동 ts 코드의 함수를 사용했던 것들은 추후 리팩토링 하는 걸로 하고 앞으로 해야될것들만 우선적으로 여기서 사용하면 될듯 합니다. 

- 각 함수 위에 주석으로 도메인 명세서의 기능명을 함께 적어두었습니다.

<img width="1427" height="1103" alt="image" src="https://github.com/user-attachments/assets/77c48cea-d424-459a-93bc-cf7569429fb6" />


<br/>

## 📢 PR Point

- 

<br/>

## 이미지 첨부


<br/>

## 🔧 다음 할 일

- https://www.notion.so/2f138c06a8ab808b94adc4bd5438eb55
- 위 링크에 바텀시트 및 저장그룹 관련 개발문서 작성해뒀습니다. 바텀시트 사용법과, 저장 관련된 페이지에 대한 간략한 설명이니 참고하셔서 다음작업 진행해도 괜찮을 것 같습니다. 
- 일부분 하드코딩 되어있는 부분은 제가 빠르게 수정하여 push  하겠습니다.

<br/> 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **북마크 관리 기능 추가**
  * 리뷰 및 팁 북마크 저장 및 삭제 기능
  * 북마크 그룹 생성, 수정, 삭제 기능
  * 저장된 북마크와 그룹 목록 조회 기능
  * 그룹별 북마크 상세 조회 및 정렬 기능

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->