### PR TITLE
Feat scrap api#3

### DIFF
--- a/src/pages/corkagemap/mystore/MyStore.tsx
+++ b/src/pages/corkagemap/mystore/MyStore.tsx
@@ -109,7 +109,7 @@ const MyStore = ({ group }: MyStoreProps) => {
             <StoreCardInSave
               key={rest.restaurantId}
               restaurantId={rest.restaurantId}
-              currentGroupId={group.id}
+              //currentGroupId={group.id}
               name={rest.name}
               rating={rest.rating}
               reviewCount={rest.reviewCount}

--- a/src/pages/corkagemap/restaurant_detail/Detail.tsx
+++ b/src/pages/corkagemap/restaurant_detail/Detail.tsx
@@ -42,7 +42,7 @@ const Detail = ({ restaurantId: propId }: DetailProps) => {
             resId={restaurant.restaurantId}
             name={restaurant.restaurantName}
             rating={restaurant.rating}
-            adr={restaurant.address}
+            //adr={restaurant.address}
             isOpen={true}
             time={restaurant.openingHours}
             phone={restaurant.phone}

--- a/src/pages/corkagemap/restaurant_detail/Detail.tsx
+++ b/src/pages/corkagemap/restaurant_detail/Detail.tsx
@@ -6,8 +6,6 @@ import DetailInfoSection from '@/shared/components/restaurant_detail/DetailInfoS
 // import { fetchRestaurant, type RestaurantInfo } from '@/shared/apis/restaurant/corkageApi';
 import { fetchRestaurant, type RestaurantInfo } from '@/shared/apis/restaurant/corkageApi';
 //import useRestaurantStore from '@/shared/store/useRestaurantStore';
-import GroupSelector from '@/shared/components/home/GroupSelector';
-import GroupList from '@/shared/components/home/GroupList';
 interface DetailProps {
   restaurantId?: number;
 }
@@ -17,7 +15,6 @@ const Detail = ({ restaurantId: propId }: DetailProps) => {
   const targetId = propId || Number(paramId);
   const [restaurant, setRestaurant] = useState<RestaurantInfo>();
   //const setRestInfo = useRestaurantStore((state) => state.setRestInfo);
-  const [isGroupSelectorOpen, setIsGroupSelectorOpen] = useState(false);
 
   useEffect(() => {
     if (!targetId) {
@@ -53,7 +50,6 @@ const Detail = ({ restaurantId: propId }: DetailProps) => {
             corkageOption={restaurant.corkageOptions}
             corkagePrice={restaurant.corkagePrice}
             isScrap={restaurant.scrap ?? false}
-            onOpenSaveList={() => setIsGroupSelectorOpen(true)}
           />
         ) : (
           <p className="flex min-h-[100svh] items-center justify-center bg-inherit">
@@ -63,22 +59,6 @@ const Detail = ({ restaurantId: propId }: DetailProps) => {
       </div>
 
       {restaurant && <DetailInfoSection {...restaurant} />}
-
-      {/* [추가] Detail 안에서 GroupSelector 직접 렌더링 */}
-      {restaurant && (
-        <GroupSelector
-          isOpen={isGroupSelectorOpen}
-          topSnapVh={17.8}
-          onClose={() => setIsGroupSelectorOpen(false)}
-        >
-          <GroupList
-            onClose={() => setIsGroupSelectorOpen(false)}
-            // 내가 API로 받아온 restaurant 객체에서 바로 전달
-            restaurantName={restaurant.restaurantName}
-            restaurantId={restaurant.restaurantId}
-          />
-        </GroupSelector>
-      )}
     </div>
   );
 };

--- a/src/shared/apis/bookmark/bookmark.api.ts
+++ b/src/shared/apis/bookmark/bookmark.api.ts
@@ -80,7 +80,7 @@ export const getBookmarkGroupDetail = async (
   return response.data;
 };
 
-// 특정 매장이 각 그룹에 저장되어 있는지 여부 조회 (storedFlag 포함)
+// 특정 매장이 각 그룹에 저장되어 있는지 여부 조회 (사용할거면 GroupListResponse 타입 groups 배열 항목에 storedFlag 추가할 것)
 export const getRestaurantBookmarkStatus = async (
   restaurantId: number
 ): Promise<GroupListResponse> => {

--- a/src/shared/apis/bookmark/bookmark.api.ts
+++ b/src/shared/apis/bookmark/bookmark.api.ts
@@ -79,3 +79,13 @@ export const getBookmarkGroupDetail = async (
   });
   return response.data;
 };
+
+// 특정 매장이 각 그룹에 저장되어 있는지 여부 조회 (storedFlag 포함)
+export const getRestaurantBookmarkStatus = async (
+  restaurantId: number
+): Promise<GroupListResponse> => {
+  const response = await apiClient.get<GroupListResponse>(
+    `/bookmarks/groups/restaurants/${restaurantId}`
+  );
+  return response.data;
+};

--- a/src/shared/components/home/CreateGroups.tsx
+++ b/src/shared/components/home/CreateGroups.tsx
@@ -15,7 +15,7 @@ import SaveMarker10 from '@/pages/corkagemap/list/savemarker/SaveMarker10.svg';
 import SaveMarker11 from '@/pages/corkagemap/list/savemarker/SaveMarker11.svg';
 import SaveMarker12 from '@/pages/corkagemap/list/savemarker/SaveMarker12.svg';
 import { useCreateGroup } from '@/shared/queries/bookmark/useCreateGroup';
-
+import { mapIconToColor } from '@/shared/utils/groupMapper';
 const markerList = [
   SaveMarker1,
   SaveMarker2,
@@ -52,7 +52,11 @@ const CreateGroup = ({ onComplete, onCancel }: EditGroupProps) => {
     }
 
     try {
-      await mutation.mutateAsync({ name: groupName, color: selectedIcon, visibility: privacy });
+      await mutation.mutateAsync({
+        name: groupName,
+        color: mapIconToColor(selectedIcon), // 변환 함수 적용
+        visibility: privacy,
+      });
       onComplete();
     } catch (e) {
       console.error('그룹 생성 실패: ' + e);

--- a/src/shared/components/home/GroupList.tsx
+++ b/src/shared/components/home/GroupList.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from 'react';
 import { AnimatePresence } from 'framer-motion';
-
+import { mapColorToIcon } from '@/shared/utils/groupMapper';
 import GroupItem from './GroupItem';
 import CreateGroup from './CreateGroups';
 import ConfirmationModal from '@/pages/corkagemap/list/ConfirmationModal';
@@ -136,7 +136,7 @@ const GroupList = ({
               <GroupItem
                 key={group.groupId}
                 id={group.groupId}
-                iconName={group.color}
+                iconName={mapColorToIcon(group.color)}
                 name={group.name}
                 count={group.storeCount}
                 checked={initialSelectedGroupIds.includes(group.groupId)}

--- a/src/shared/components/home/GroupSelector.tsx
+++ b/src/shared/components/home/GroupSelector.tsx
@@ -1,4 +1,5 @@
 import { motion, useMotionValue, useTransform, animate } from 'framer-motion';
+import { createPortal } from 'react-dom';
 import { useState, useEffect } from 'react';
 import type { ReactNode } from 'react';
 import type { PanInfo } from 'framer-motion';
@@ -117,8 +118,9 @@ const GroupSelector = ({
       onClose(); // (useEffect[isOpen]이 y를 HIDDEN으로 애니메이션함)
     }
   };
+  if (typeof window === 'undefined') return null; // SSR 대응
 
-  return (
+  return createPortal(
     <>
       {/* 1. 뒷 배경 (어둡게 처리) */}
       <motion.div
@@ -162,7 +164,8 @@ const GroupSelector = ({
           {children}
         </div>
       </motion.div>
-    </>
+    </>,
+    document.body
   );
 };
 

--- a/src/shared/components/restaurant_detail/DetailHeader.tsx
+++ b/src/shared/components/restaurant_detail/DetailHeader.tsx
@@ -44,6 +44,7 @@ const DetailHeader = ({
   isScrap,
   onOpenSaveList,
 }: detailProps) => {
+  const displayRating = Number(rating).toFixed(1);
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -148,7 +149,7 @@ const DetailHeader = ({
           <div className="flex items-center">
             <span className="mr-2 text-sm font-medium">콜키지리뷰</span>
             <img src={star} />
-            <span className="ml-1 font-medium">{rating}</span>
+            <span className="ml-1 font-medium">{displayRating}</span>
           </div>
           <div className="mt-1 flex items-center gap-2 text-[14px]">
             <span className="font-semibold">{isOpen ? '영업중' : '영업종료'}</span>

--- a/src/shared/components/restaurant_detail/DetailHeader.tsx
+++ b/src/shared/components/restaurant_detail/DetailHeader.tsx
@@ -105,9 +105,9 @@ const DetailHeader = ({
         <div>
           <div className="flex flex-row gap-[8px]">
             <div className="text-[24px] font-bold">{name}</div>
-            <div className="cursor-pointer" onClick={() => setIsGroupSelectorOpen(true)}>
+            <button onClick={() => setIsGroupSelectorOpen(true)}>
               <img src={isScrap ? save : notsave} alt="bookmark" className="h-[32px] w-[32px]" />
-            </div>
+            </button>
           </div>
           <div className="flex items-center">
             <span className="mr-2 text-sm font-medium">콜키지리뷰</span>

--- a/src/shared/components/restaurant_detail/DetailHeader.tsx
+++ b/src/shared/components/restaurant_detail/DetailHeader.tsx
@@ -58,13 +58,19 @@ const DetailHeader = ({
   const selectedStores = useBookmarkStore((state) => state.selectedStores);
 
   useEffect(() => {
-    // 스토어에 현재 매장 ID가 존재하는지 여부를 확인
-    setIsKeep(resId in selectedStores);
-  }, [resId, selectedStores]);
+    // 1. 전역 스토어(Zustand)에 현재 매장에 대한 데이터가 한 번이라도 담겼다면 (저장 혹은 수정 이력 있음)
+    if (resId in selectedStores) {
+      // 해당 매장이 속한 그룹 배열이 비어있지 않은지 확인 (더 정확한 체크)
+      setIsKeep(selectedStores[resId].length > 0);
+    }
+    // 2. 스토어에 데이터가 없다면, 아직 이 세션에서 수정한 적이 없으므로 서버 값(isScrap)을 유지합니다.
+    else {
+      setIsKeep(isScrap);
+    }
+  }, [resId, selectedStores, isScrap]);
 
   const handleCloseGroupSelector = () => {
     setIsGroupSelectorOpen(false);
-    setIsKeep(resId in selectedStores);
   };
 
   // 좌우 overflow 감지

--- a/src/shared/components/restaurant_detail/DetailHeader.tsx
+++ b/src/shared/components/restaurant_detail/DetailHeader.tsx
@@ -4,7 +4,7 @@ import GroupSelector from '@/shared/components/home/GroupSelector';
 import GroupList from '@/shared/components/home/GroupList';
 import Modal from '../common/Modal';
 import Button from '../common/Button';
-
+import useBookmarkStore from '@/shared/store/useBookmarkStore';
 import smallGlass from '../../assets/smallGlass.svg';
 import star from '../../assets/star.svg';
 import call from '../../assets/detailPageImgs/call.svg';
@@ -43,6 +43,7 @@ const DetailHeader = ({
   corkagePrice,
   isScrap,
 }: detailProps) => {
+  const [isKeep, setIsKeep] = useState(isScrap);
   const displayRating = Number(rating).toFixed(1);
   const navigate = useNavigate();
   const [isContactModalOpen, setIsContactModalOpen] = useState(false); // 문의하기 modal 열기
@@ -54,6 +55,17 @@ const DetailHeader = ({
   const [isOverflow, setIsOverflow] = useState(false); // 버튼 그룹 overflow 감지
   const [isGroupSelectorOpen, setIsGroupSelectorOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+  const selectedStores = useBookmarkStore((state) => state.selectedStores);
+
+  useEffect(() => {
+    // 스토어에 현재 매장 ID가 존재하는지 여부를 확인
+    setIsKeep(resId in selectedStores);
+  }, [resId, selectedStores]);
+
+  const handleCloseGroupSelector = () => {
+    setIsGroupSelectorOpen(false);
+    setIsKeep(resId in selectedStores);
+  };
 
   // 좌우 overflow 감지
   useEffect(() => {
@@ -106,7 +118,7 @@ const DetailHeader = ({
           <div className="flex flex-row gap-[8px]">
             <div className="text-[24px] font-bold">{name}</div>
             <button onClick={() => setIsGroupSelectorOpen(true)}>
-              <img src={isScrap ? save : notsave} alt="bookmark" className="h-[32px] w-[32px]" />
+              <img src={isKeep ? save : notsave} alt="bookmark" className="h-[32px] w-[32px]" />
             </button>
           </div>
           <div className="flex items-center">
@@ -280,13 +292,9 @@ const DetailHeader = ({
       <GroupSelector
         isOpen={isGroupSelectorOpen}
         topSnapVh={17.8}
-        onClose={() => setIsGroupSelectorOpen(false)}
+        onClose={handleCloseGroupSelector}
       >
-        <GroupList
-          onClose={() => setIsGroupSelectorOpen(false)}
-          restaurantName={name}
-          restaurantId={resId}
-        />
+        <GroupList onClose={handleCloseGroupSelector} restaurantName={name} restaurantId={resId} />
       </GroupSelector>
     </div>
   );

--- a/src/shared/components/restaurant_detail/DetailHeader.tsx
+++ b/src/shared/components/restaurant_detail/DetailHeader.tsx
@@ -1,6 +1,7 @@
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useState, useEffect, useRef } from 'react';
-import { editBookmarkGroup } from '@/shared/apis/bookmark/bookmark.api';
+import GroupSelector from '@/shared/components/home/GroupSelector';
+import GroupList from '@/shared/components/home/GroupList';
 import Modal from '../common/Modal';
 import Button from '../common/Button';
 
@@ -28,7 +29,6 @@ interface detailProps {
   corkageOption: string[];
   corkagePrice: string;
   isScrap: boolean; // [중요] 부모로부터 현재 스크랩 상태를 받아야 함 (restaurant.scrap)
-  onOpenSaveList: () => void; // [중요] 저장 안 된 상태에서 누르면 부모(CorkageMap)에게 리스트 열라고 요청
 }
 
 const DetailHeader = ({
@@ -42,38 +42,11 @@ const DetailHeader = ({
   corkageOption,
   corkagePrice,
   isScrap,
-  onOpenSaveList,
 }: detailProps) => {
   const displayRating = Number(rating).toFixed(1);
   const navigate = useNavigate();
   const location = useLocation();
-
-  const [isKeep, setIsKeep] = useState(false);
-
-  useEffect(() => {
-    setIsKeep(isScrap);
-  }, [isScrap]);
-
-  const handleBookmarkClick = async () => {
-    if (isKeep) {
-      // 1. 이미 저장됨 -> 저장 취소 (모든 그룹에서 제거)
-      try {
-        // [API] groupIds: [] 빈 배열을 보내면 저장 취소됨
-        const res = await editBookmarkGroup({ restaurantId: resId, groupIds: [] });
-
-        if (res.success) {
-          setIsKeep(false);
-          alert('저장이 취소되었습니다.');
-        }
-      } catch (e) {
-        console.error('저장 취소 실패', e);
-        alert('저장 취소 중 오류가 발생했습니다.');
-      }
-    } else {
-      // 2. 저장 안 됨 -> 그룹 선택창(List) 열기
-      onOpenSaveList();
-    }
-  };
+  //const selectedStores = useBookmarkStore((state) => state.selectedStores);
 
   const [isContactModalOpen, setIsContactModalOpen] = useState(false); // 문의하기 modal 열기
   const [contactContent, setContactContent] = useState('');
@@ -82,7 +55,7 @@ const DetailHeader = ({
   const [isCallModalOpen, setIsCallModalOpen] = useState(false); // 전화하기 modal 열기
   const [isCopiedModalOpen, setIsCopiedModalOpen] = useState(false); // 복사완료 modal 열기
   const [isOverflow, setIsOverflow] = useState(false); // 버튼 그룹 overflow 감지
-
+  const [isGroupSelectorOpen, setIsGroupSelectorOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
   // const location = useLocation();
@@ -142,8 +115,8 @@ const DetailHeader = ({
         <div>
           <div className="flex flex-row gap-[8px]">
             <div className="text-[24px] font-bold">{name}</div>
-            <div className="cursor-pointer" onClick={handleBookmarkClick}>
-              <img src={isKeep ? save : notsave} alt="bookmark" className="h-[32px] w-[32px]" />
+            <div className="cursor-pointer" onClick={() => setIsGroupSelectorOpen(true)}>
+              <img src={isScrap ? save : notsave} alt="bookmark" className="h-[32px] w-[32px]" />
             </div>
           </div>
           <div className="flex items-center">
@@ -312,6 +285,19 @@ const DetailHeader = ({
           </div>
         </div>
       )}
+
+      {/* [추가] Detail 안에서 GroupSelector 직접 렌더링 */}
+      <GroupSelector
+        isOpen={isGroupSelectorOpen}
+        topSnapVh={17.8}
+        onClose={() => setIsGroupSelectorOpen(false)}
+      >
+        <GroupList
+          onClose={() => setIsGroupSelectorOpen(false)}
+          restaurantName={name}
+          restaurantId={resId}
+        />
+      </GroupSelector>
     </div>
   );
 };

--- a/src/shared/components/restaurant_detail/DetailHeader.tsx
+++ b/src/shared/components/restaurant_detail/DetailHeader.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useState, useEffect, useRef } from 'react';
 import GroupSelector from '@/shared/components/home/GroupSelector';
 import GroupList from '@/shared/components/home/GroupList';
@@ -20,8 +20,8 @@ interface detailProps {
   resId: number;
   name: string;
   rating: number;
-  adr: string;
-  alias?: string;
+  //adr: string;
+  //alias?: string;
   isOpen: boolean;
   time: string;
   phone: string;
@@ -45,9 +45,6 @@ const DetailHeader = ({
 }: detailProps) => {
   const displayRating = Number(rating).toFixed(1);
   const navigate = useNavigate();
-  const location = useLocation();
-  //const selectedStores = useBookmarkStore((state) => state.selectedStores);
-
   const [isContactModalOpen, setIsContactModalOpen] = useState(false); // 문의하기 modal 열기
   const [contactContent, setContactContent] = useState('');
   const [contactOption, setContactOption] = useState(true); // true: 콜키지정보오류, false: 가게 정보 오류
@@ -57,13 +54,6 @@ const DetailHeader = ({
   const [isOverflow, setIsOverflow] = useState(false); // 버튼 그룹 overflow 감지
   const [isGroupSelectorOpen, setIsGroupSelectorOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
-
-  // const location = useLocation();
-
-  useEffect(() => {
-    // state 초기화 (새로고침 시 안 뜨게)
-    //navigate(`/detail-info/${resId}`, { replace: true });
-  }, [location.state]);
 
   // 좌우 overflow 감지
   useEffect(() => {

--- a/src/shared/components/storecard/StoreCardInMultiPinList.tsx
+++ b/src/shared/components/storecard/StoreCardInMultiPinList.tsx
@@ -70,21 +70,25 @@ const StoreCard = ({
   const [isKeep, setIsKeep] = useState(scrap);
 
   useEffect(() => {
-    setIsKeep(scrap);
-  }, [scrap]);
+    // 사용자가 현재 세션에서 한 번이라도 조작을 해서 스토어에 데이터가 담겼는지 확인
+    const hasUserAction = resId in selectedStores;
 
-  useEffect(() => {
-    // 스토어에 현재 매장 ID가 있는지 확인
-    const isCurrentlyInStore = resId in selectedStores;
+    if (hasUserAction) {
+      // 조작 이력이 있다면 스토어의 최신 상태를 반영
+      setIsKeep(selectedStores[resId].length > 0);
+    } else {
+      // 조작 이력이 없다면 초기 서버 데이터(scrap)를 신뢰함
+      setIsKeep(scrap);
+    }
+  }, [resId, selectedStores, scrap]);
 
-    // 만약 스토어에 데이터가 있다면 (배열이 비어있지 않다면) 저장된 것으로 간주
-    // (스토어 구조에 따라 selectedStores[resId]?.length > 0 등의 조건이 필요할 수 있습니다)
-    setIsKeep(isCurrentlyInStore);
-  }, [resId, selectedStores]);
-
-  // [수정] 그룹 셀렉터가 닫힐 때 실행될 핸들러
+  // [해결 2] 그룹 셀렉터가 닫힐 때 최신 상태 확정
   const handleCloseGroupSelector = () => {
     setIsGroupSelectorOpen(false);
+    // 닫히는 시점의 스토어 상태를 다시 한번 동기화
+    if (resId in selectedStores) {
+      setIsKeep(selectedStores[resId].length > 0);
+    }
   };
 
   return (
@@ -213,11 +217,14 @@ const StoreCard = ({
           topSnapVh={17.8}
           onClose={handleCloseGroupSelector}
         >
-          <GroupList
-            onClose={handleCloseGroupSelector}
-            restaurantName={name} // Props로 받은 name 사용
-            restaurantId={resId} // Props로 받은 resId 사용
-          />
+          {isGroupSelectorOpen && (
+            <GroupList
+              key={`group-list-${resId}-${isGroupSelectorOpen}`}
+              onClose={handleCloseGroupSelector}
+              restaurantName={name}
+              restaurantId={resId}
+            />
+          )}
         </GroupSelector>
       </div>
     </div>

--- a/src/shared/components/storecard/StoreCardInMultiPinList.tsx
+++ b/src/shared/components/storecard/StoreCardInMultiPinList.tsx
@@ -1,9 +1,14 @@
+import { useState, useEffect } from 'react';
 import Save from './save.svg';
 import NotSave from './notsave.svg'; // 필요시 사용
 import Share from './share.svg';
 import Star from '../../assets/star.svg';
 import DummyFood from './dummyFood.svg';
 import { useNavigate } from 'react-router-dom';
+
+import GroupSelector from '../home/GroupSelector';
+import GroupList from '../home/GroupList';
+
 // [수정] API 데이터 타입에 맞춰 Props 인터페이스 정의
 interface StoreCardProps {
   resId: number;
@@ -34,13 +39,32 @@ const StoreCard = ({
     e.currentTarget.src = DummyFood; // 에러 시 더미 이미지로 대체
   };
 
-  // 버튼 클릭 이벤트 전파 방지 (카드 클릭과 분리)
-  const handleButtonClick = (e: React.MouseEvent<HTMLButtonElement>, action: string) => {
-    e.stopPropagation();
-    console.log(`${action} 버튼 클릭: ${resId}`);
-    // 추후 스크랩/공유 로직 연결
+  const handleBookmarkClick = (e: React.MouseEvent) => {
+    e.stopPropagation(); // 카드 클릭(상세이동) 이벤트 방지
+
+    if (isKeep) {
+      // 이미 저장된 경우: 보통은 여기서 바로 해제 API를 쏘거나 확인 모달을 띄움
+      console.log('이미 저장됨: 해제 로직 필요');
+      // 예: if(confirm('저장을 취소하시겠습니까?')) { ... API 호출 ... }
+    } else {
+      // 저장 안 된 경우: 그룹 선택 바텀시트 열기
+      setIsGroupSelectorOpen(true);
+    }
   };
+
+  const handleShareClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    console.log('공유 클릭');
+  };
+
   const navigate = useNavigate();
+  const [isKeep, setIsKeep] = useState(scrap);
+
+  useEffect(() => {
+    setIsKeep(scrap);
+  }, [scrap]);
+
+  const [isGroupSelectorOpen, setIsGroupSelectorOpen] = useState(false);
   return (
     <div
       className="flex w-full flex-col bg-white"
@@ -52,11 +76,11 @@ const StoreCard = ({
         <h2 className="text-[20px] font-bold leading-none text-[#35353F]">{name}</h2>
         {/* 우측 아이콘 버튼들 */}
         <div className="flex gap-[4px]">
-          <button type="button" onClick={(e) => handleButtonClick(e, 'Scrap')}>
+          <button type="button" onClick={handleBookmarkClick}>
             {/* scrap ? Save : NotSave */}
-            <img src={scrap ? Save : NotSave} alt="save" className="h-[25px] w-[25px]" />
+            <img src={isKeep ? Save : NotSave} alt="save" className="h-[25px] w-[25px]" />
           </button>
-          <button type="button" onClick={(e) => handleButtonClick(e, 'Share')}>
+          <button type="button" onClick={handleShareClick}>
             <img src={Share} alt="share" className="h-[25px] w-[25px]" />
           </button>
         </div>
@@ -127,6 +151,21 @@ const StoreCard = ({
             {corkageOptions?.join(', ')}
           </span>
         </div>
+      </div>
+
+      <div onClick={(e) => e.stopPropagation()}>
+        {/* [추가] 카드별로 독립적인 GroupSelector 배치 */}
+        <GroupSelector
+          isOpen={isGroupSelectorOpen}
+          topSnapVh={17.8}
+          onClose={() => setIsGroupSelectorOpen(false)}
+        >
+          <GroupList
+            onClose={() => setIsGroupSelectorOpen(false)}
+            restaurantName={name} // Props로 받은 name 사용
+            restaurantId={resId} // Props로 받은 resId 사용
+          />
+        </GroupSelector>
       </div>
     </div>
   );

--- a/src/shared/components/storecard/StoreCardInMultiPinList.tsx
+++ b/src/shared/components/storecard/StoreCardInMultiPinList.tsx
@@ -35,22 +35,15 @@ const StoreCard = ({
   openingHours,
 }: StoreCardProps) => {
   const displayRating = Number(rating).toFixed(1);
+  const [isGroupSelectorOpen, setIsGroupSelectorOpen] = useState(false);
   // 이미지 로드 에러 시 처리를 위한 핸들러
   const handleImageError = (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
     e.currentTarget.src = DummyFood; // 에러 시 더미 이미지로 대체
   };
 
-  const handleBookmarkClick = (e: React.MouseEvent) => {
-    e.stopPropagation(); // 카드 클릭(상세이동) 이벤트 방지
-
-    if (isKeep) {
-      // 이미 저장된 경우: 보통은 여기서 바로 해제 API를 쏘거나 확인 모달을 띄움
-      console.log('이미 저장됨: 해제 로직 필요');
-      // 예: if(confirm('저장을 취소하시겠습니까?')) { ... API 호출 ... }
-    } else {
-      // 저장 안 된 경우: 그룹 선택 바텀시트 열기
-      setIsGroupSelectorOpen(true);
-    }
+  const handleKeepClick = (e: React.MouseEvent) => {
+    e.stopPropagation(); // 부모 div로의 이벤트 전파를 막습니다.
+    setIsGroupSelectorOpen(true);
   };
 
   const handleShareClick = (e: React.MouseEvent) => {
@@ -64,8 +57,6 @@ const StoreCard = ({
   useEffect(() => {
     setIsKeep(scrap);
   }, [scrap]);
-
-  const [isGroupSelectorOpen, setIsGroupSelectorOpen] = useState(false);
   return (
     <div
       className="flex w-full flex-col bg-white"
@@ -77,7 +68,7 @@ const StoreCard = ({
         <h2 className="text-[20px] font-bold leading-none text-[#35353F]">{name}</h2>
         {/* 우측 아이콘 버튼들 */}
         <div className="flex gap-[4px]">
-          <button type="button" onClick={handleBookmarkClick}>
+          <button type="button" onClick={handleKeepClick}>
             {/* scrap ? Save : NotSave */}
             <img src={isKeep ? Save : NotSave} alt="save" className="h-[25px] w-[25px]" />
           </button>

--- a/src/shared/components/storecard/StoreCardInMultiPinList.tsx
+++ b/src/shared/components/storecard/StoreCardInMultiPinList.tsx
@@ -5,7 +5,7 @@ import Share from './share.svg';
 import Star from '../../assets/star.svg';
 import DummyFood from './dummyFood.svg';
 import { useNavigate } from 'react-router-dom';
-
+import useBookmarkStore from '@/shared/store/useBookmarkStore';
 import GroupSelector from '../home/GroupSelector';
 import GroupList from '../home/GroupList';
 import Modal from '../common/Modal';
@@ -42,6 +42,7 @@ const StoreCard = ({
   const [isGroupSelectorOpen, setIsGroupSelectorOpen] = useState(false);
   const [isShareModalOpen, setIsShareModalOpen] = useState(false); // 공유하기 modal 열기
   const [isCopiedModalOpen, setIsCopiedModalOpen] = useState(false); // 복사완료 modal 열기
+  const selectedStores = useBookmarkStore((state) => state.selectedStores);
   // 이미지 로드 에러 시 처리를 위한 핸들러
   const handleImageError = (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
     e.currentTarget.src = DummyFood; // 에러 시 더미 이미지로 대체
@@ -71,6 +72,21 @@ const StoreCard = ({
   useEffect(() => {
     setIsKeep(scrap);
   }, [scrap]);
+
+  useEffect(() => {
+    // 스토어에 현재 매장 ID가 있는지 확인
+    const isCurrentlyInStore = resId in selectedStores;
+
+    // 만약 스토어에 데이터가 있다면 (배열이 비어있지 않다면) 저장된 것으로 간주
+    // (스토어 구조에 따라 selectedStores[resId]?.length > 0 등의 조건이 필요할 수 있습니다)
+    setIsKeep(isCurrentlyInStore);
+  }, [resId, selectedStores]);
+
+  // [수정] 그룹 셀렉터가 닫힐 때 실행될 핸들러
+  const handleCloseGroupSelector = () => {
+    setIsGroupSelectorOpen(false);
+  };
+
   return (
     <div
       className="flex w-full flex-col bg-white"
@@ -195,10 +211,10 @@ const StoreCard = ({
         <GroupSelector
           isOpen={isGroupSelectorOpen}
           topSnapVh={17.8}
-          onClose={() => setIsGroupSelectorOpen(false)}
+          onClose={handleCloseGroupSelector}
         >
           <GroupList
-            onClose={() => setIsGroupSelectorOpen(false)}
+            onClose={handleCloseGroupSelector}
             restaurantName={name} // Props로 받은 name 사용
             restaurantId={resId} // Props로 받은 resId 사용
           />

--- a/src/shared/components/storecard/StoreCardInMultiPinList.tsx
+++ b/src/shared/components/storecard/StoreCardInMultiPinList.tsx
@@ -34,6 +34,7 @@ const StoreCard = ({
   imageUrls,
   openingHours,
 }: StoreCardProps) => {
+  const displayRating = Number(rating).toFixed(1);
   // 이미지 로드 에러 시 처리를 위한 핸들러
   const handleImageError = (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
     e.currentTarget.src = DummyFood; // 에러 시 더미 이미지로 대체
@@ -91,7 +92,7 @@ const StoreCard = ({
         <img src={Star} alt="star" className="h-[15px] w-[16px]" />
 
         {/* 평점 */}
-        <span className="ml-[4px] text-[16px] font-[500] text-[#35353F]">{rating}</span>
+        <span className="ml-[4px] text-[16px] font-[500] text-[#35353F]">{displayRating}</span>
 
         {/* 리뷰 수 */}
         <span className="ml-[4px] text-[14px] font-[500] text-[#9FA2AA]">({reviewCount})</span>
@@ -157,7 +158,7 @@ const StoreCard = ({
         {/* [추가] 카드별로 독립적인 GroupSelector 배치 */}
         <GroupSelector
           isOpen={isGroupSelectorOpen}
-          topSnapVh={17.8}
+          topSnapVh={-10}
           onClose={() => setIsGroupSelectorOpen(false)}
         >
           <GroupList

--- a/src/shared/components/storecard/StoreCardInMultiPinList.tsx
+++ b/src/shared/components/storecard/StoreCardInMultiPinList.tsx
@@ -8,6 +8,10 @@ import { useNavigate } from 'react-router-dom';
 
 import GroupSelector from '../home/GroupSelector';
 import GroupList from '../home/GroupList';
+import Modal from '../common/Modal';
+import Button from '../common/Button';
+import check from '../../components/detail/assets/check.svg';
+import logo from '@/shared/assets/images/logo.svg';
 
 // [수정] API 데이터 타입에 맞춰 Props 인터페이스 정의
 interface StoreCardProps {
@@ -36,6 +40,8 @@ const StoreCard = ({
 }: StoreCardProps) => {
   const displayRating = Number(rating).toFixed(1);
   const [isGroupSelectorOpen, setIsGroupSelectorOpen] = useState(false);
+  const [isShareModalOpen, setIsShareModalOpen] = useState(false); // 공유하기 modal 열기
+  const [isCopiedModalOpen, setIsCopiedModalOpen] = useState(false); // 복사완료 modal 열기
   // 이미지 로드 에러 시 처리를 위한 핸들러
   const handleImageError = (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
     e.currentTarget.src = DummyFood; // 에러 시 더미 이미지로 대체
@@ -47,8 +53,16 @@ const StoreCard = ({
   };
 
   const handleShareClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    console.log('공유 클릭');
+    e.stopPropagation(); // 부모 div로의 이벤트 전파를 막습니다.
+    setIsShareModalOpen(true);
+  };
+
+  // 공유 클릭 시 주소 복사
+  const clipLink = () => {
+    navigator.clipboard.writeText(window.location.href);
+    setIsShareModalOpen(false);
+    setIsCopiedModalOpen(true);
+    setTimeout(() => setIsCopiedModalOpen(false), 1000);
   };
 
   const navigate = useNavigate();
@@ -144,6 +158,37 @@ const StoreCard = ({
           </span>
         </div>
       </div>
+
+      {/* 공유하기 모달 */}
+      <div onClick={(e) => e.stopPropagation()}>
+        <Modal
+          isOpen={isShareModalOpen}
+          hasCloseButton={true}
+          onClose={() => setIsShareModalOpen(false)}
+        >
+          <div className="mb-4 flex items-center">
+            <img src={logo} className="h-[22px] w-[13px]" />
+            <div className="ml-3 flex flex-col">
+              <span className="font-semibold">{name}</span>
+              <span className="text-xs text-[rgba(60,60,67,0.6)]">corkcharge.com</span>
+            </div>
+          </div>
+          <Button
+            value="링크 복사하기"
+            className="bg-[var(--gray-1)] text-[var(--gray-8)] shadow-none"
+            onClick={clipLink}
+          />
+        </Modal>
+      </div>
+
+      {/* 복사완료 모달 */}
+      {isCopiedModalOpen && (
+        <div className="fixed inset-0 z-50 flex justify-center bg-black/50">
+          <div className="absolute top-12 flex h-12 w-[125px] items-center justify-center rounded-xl bg-white p-6 font-semibold text-[var(--primary)] shadow-lg">
+            <img src={check} />
+          </div>
+        </div>
+      )}
 
       <div onClick={(e) => e.stopPropagation()}>
         {/* [추가] 카드별로 독립적인 GroupSelector 배치 */}

--- a/src/shared/components/storecard/StoreCardInMultiPinList.tsx
+++ b/src/shared/components/storecard/StoreCardInMultiPinList.tsx
@@ -59,7 +59,7 @@ const StoreCard = ({
 
   // 공유 클릭 시 주소 복사
   const clipLink = () => {
-    navigator.clipboard.writeText(window.location.href);
+    navigator.clipboard.writeText(`${window.location.origin}/detail-info/${resId}`); // 해당 매장의 상세정보 페이지 주소를 복사
     setIsShareModalOpen(false);
     setIsCopiedModalOpen(true);
     setTimeout(() => setIsCopiedModalOpen(false), 1000);

--- a/src/shared/components/storecard/StoreCardInMultiPinList.tsx
+++ b/src/shared/components/storecard/StoreCardInMultiPinList.tsx
@@ -158,7 +158,7 @@ const StoreCard = ({
         {/* [추가] 카드별로 독립적인 GroupSelector 배치 */}
         <GroupSelector
           isOpen={isGroupSelectorOpen}
-          topSnapVh={-10}
+          topSnapVh={17.8}
           onClose={() => setIsGroupSelectorOpen(false)}
         >
           <GroupList

--- a/src/shared/components/storecard/StoreCardInSave.tsx
+++ b/src/shared/components/storecard/StoreCardInSave.tsx
@@ -32,6 +32,7 @@ const StoreCardInSave = ({
 }: StoreCardProps) => {
   const [isSaved, setIsSaved] = useState(true);
   const navigate = useNavigate();
+  const displayRating = Number(rating).toFixed(1);
 
   // 저장 토글 핸들러
   const handleToggleSave = async (e: React.MouseEvent) => {
@@ -81,7 +82,7 @@ const StoreCardInSave = ({
         <img src={Star} alt="star" className="h-[15px] w-[16px]" />
 
         {/* 평점 */}
-        <span className="ml-[4px] text-[16px] font-[500] text-[#35353F]">{rating}</span>
+        <span className="ml-[4px] text-[16px] font-[500] text-[#35353F]">{displayRating}</span>
 
         {/* 리뷰 수 */}
         <span className="ml-[4px] text-[14px] font-[500] text-[#9FA2AA]">({reviewCount})</span>

--- a/src/shared/components/storecard/StoreCardInSave.tsx
+++ b/src/shared/components/storecard/StoreCardInSave.tsx
@@ -8,6 +8,10 @@ import useBookmarkStore from '@/shared/store/useBookmarkStore';
 import GroupSelector from '@/shared/components/home/GroupSelector';
 import GroupList from '@/shared/components/home/GroupList';
 import { useNavigate } from 'react-router-dom';
+import Modal from '../common/Modal';
+import Button from '../common/Button';
+import check from '../../components/detail/assets/check.svg';
+import logo from '@/shared/assets/images/logo.svg';
 
 interface StoreCardProps {
   restaurantId: number;
@@ -34,7 +38,8 @@ const StoreCardInSave = ({
   const [isGroupSelectorOpen, setIsGroupSelectorOpen] = useState(false); // 그룹 선택 바텀 시트 열기
   const navigate = useNavigate();
   const displayRating = Number(rating).toFixed(1);
-
+  const [isShareModalOpen, setIsShareModalOpen] = useState(false); // 공유하기 modal 열기
+  const [isCopiedModalOpen, setIsCopiedModalOpen] = useState(false); // 복사완료 modal 열기
   const selectedStores = useBookmarkStore((state) => state.selectedStores);
 
   const handleKeepClick = (e: React.MouseEvent) => {
@@ -44,7 +49,15 @@ const StoreCardInSave = ({
 
   const handleShareClick = (e: React.MouseEvent) => {
     e.stopPropagation(); // 부모 div로의 이벤트 전파를 막습니다.
-    console.log('공유하기 클릭'); // 여기에 공유 로직 추가
+    setIsShareModalOpen(true);
+  };
+
+  // 공유 클릭 시 주소 복사
+  const clipLink = () => {
+    navigator.clipboard.writeText(window.location.href);
+    setIsShareModalOpen(false);
+    setIsCopiedModalOpen(true);
+    setTimeout(() => setIsCopiedModalOpen(false), 1000);
   };
 
   useEffect(() => {
@@ -135,6 +148,37 @@ const StoreCardInSave = ({
           </span>
         </div>
       </div>
+
+      {/* 공유하기 모달 */}
+      <div onClick={(e) => e.stopPropagation()}>
+        <Modal
+          isOpen={isShareModalOpen}
+          hasCloseButton={true}
+          onClose={() => setIsShareModalOpen(false)}
+        >
+          <div className="mb-4 flex items-center">
+            <img src={logo} className="h-[22px] w-[13px]" />
+            <div className="ml-3 flex flex-col">
+              <span className="font-semibold">{name}</span>
+              <span className="text-xs text-[rgba(60,60,67,0.6)]">corkcharge.com</span>
+            </div>
+          </div>
+          <Button
+            value="링크 복사하기"
+            className="bg-[var(--gray-1)] text-[var(--gray-8)] shadow-none"
+            onClick={clipLink}
+          />
+        </Modal>
+      </div>
+
+      {/* 복사완료 모달 */}
+      {isCopiedModalOpen && (
+        <div className="fixed inset-0 z-50 flex justify-center bg-black/50">
+          <div className="absolute top-12 flex h-12 w-[125px] items-center justify-center rounded-xl bg-white p-6 font-semibold text-[var(--primary)] shadow-lg">
+            <img src={check} />
+          </div>
+        </div>
+      )}
 
       {/* [추가] Detail 안에서 GroupSelector 직접 렌더링 */}
       <div onClick={(e) => e.stopPropagation()}>

--- a/src/shared/components/storecard/StoreCardInSave.tsx
+++ b/src/shared/components/storecard/StoreCardInSave.tsx
@@ -1,15 +1,16 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Save from './save.svg';
 import NotSave from './notsave.svg'; // 필요시 사용
 import Share from './share.svg';
 import Star from '../../assets/star.svg';
 import DummyFood from './dummyFood.svg';
-import { editBookmarkGroup } from '@/shared/apis/bookmark/bookmark.api';
+import useBookmarkStore from '@/shared/store/useBookmarkStore';
+import GroupSelector from '@/shared/components/home/GroupSelector';
+import GroupList from '@/shared/components/home/GroupList';
 import { useNavigate } from 'react-router-dom';
 
 interface StoreCardProps {
   restaurantId: number;
-  currentGroupId: number;
   name: string;
   rating: number;
   reviewCount: number;
@@ -21,7 +22,6 @@ interface StoreCardProps {
 
 const StoreCardInSave = ({
   restaurantId,
-  currentGroupId,
   name,
   rating,
   reviewCount,
@@ -30,28 +30,26 @@ const StoreCardInSave = ({
   corkagePrice,
   corkageOption,
 }: StoreCardProps) => {
-  const [isSaved, setIsSaved] = useState(true);
+  const [isKeep, setIsKeep] = useState(true);
+  const [isGroupSelectorOpen, setIsGroupSelectorOpen] = useState(false); // 그룹 선택 바텀 시트 열기
   const navigate = useNavigate();
   const displayRating = Number(rating).toFixed(1);
 
-  // 저장 토글 핸들러
-  const handleToggleSave = async (e: React.MouseEvent) => {
-    e.stopPropagation();
-    try {
-      if (isSaved) {
-        // [저장 취소] -> 그룹에서 제거
-        await editBookmarkGroup({ restaurantId, groupIds: [] });
-        setIsSaved(false);
-      } else {
-        // [다시 저장] -> 현재 그룹에 다시 추가
-        await editBookmarkGroup({ restaurantId, groupIds: [currentGroupId] });
-        setIsSaved(true);
-      }
-    } catch (error) {
-      console.error('저장 상태 변경 실패', error);
-      alert('요청을 처리하는 중 오류가 발생했습니다.');
-    }
+  const selectedStores = useBookmarkStore((state) => state.selectedStores);
+
+  const handleKeepClick = (e: React.MouseEvent) => {
+    e.stopPropagation(); // 부모 div로의 이벤트 전파를 막습니다.
+    setIsGroupSelectorOpen(true);
   };
+
+  const handleShareClick = (e: React.MouseEvent) => {
+    e.stopPropagation(); // 부모 div로의 이벤트 전파를 막습니다.
+    console.log('공유하기 클릭'); // 여기에 공유 로직 추가
+  };
+
+  useEffect(() => {
+    setIsKeep(restaurantId in selectedStores);
+  }, [restaurantId, selectedStores]);
 
   return (
     <div
@@ -64,14 +62,15 @@ const StoreCardInSave = ({
         <h2 className="text-[20px] font-bold leading-none text-[#35353F]">{name}</h2>
         {/* 우측 아이콘 버튼들 */}
         <div className="flex gap-[4px]">
-          <button type="button" onClick={handleToggleSave}>
+          <button type="button">
             <img
-              src={isSaved ? Save : NotSave}
-              alt={isSaved ? 'saved' : 'unsaved'}
+              src={isKeep ? Save : NotSave}
+              alt={isKeep ? 'saved' : 'unsaved'}
+              onClick={handleKeepClick}
               className="h-[25px] w-[25px]"
             />
           </button>
-          <button type="button">
+          <button type="button" onClick={handleShareClick}>
             <img src={Share} alt="share" className="h-[25px] w-[25px]" />
           </button>
         </div>
@@ -136,6 +135,22 @@ const StoreCardInSave = ({
             {corkageOption}
           </span>
         </div>
+      </div>
+
+      {/* [추가] Detail 안에서 GroupSelector 직접 렌더링 */}
+      <div onClick={(e) => e.stopPropagation()}>
+        <GroupSelector
+          isOpen={isGroupSelectorOpen}
+          topSnapVh={17.8}
+          onClose={() => setIsGroupSelectorOpen(false)}
+        >
+          <GroupList
+            onClose={() => setIsGroupSelectorOpen(false)}
+            // 선택된 식당 상태에서 데이터를 가져와 전달
+            restaurantName={name}
+            restaurantId={restaurantId}
+          />
+        </GroupSelector>
       </div>
     </div>
   );

--- a/src/shared/components/storecard/StoreCardInSave.tsx
+++ b/src/shared/components/storecard/StoreCardInSave.tsx
@@ -47,6 +47,14 @@ const StoreCardInSave = ({
     setIsGroupSelectorOpen(true);
   };
 
+  const handleCloseGroupSelector = () => {
+    setIsGroupSelectorOpen(false);
+
+    // 전역 스토어에 해당 매장 ID가 있는지 확인 (있으면 true, 없으면 false)
+    const isCurrentlySaved = restaurantId in selectedStores;
+    setIsKeep(isCurrentlySaved);
+  };
+
   const handleShareClick = (e: React.MouseEvent) => {
     e.stopPropagation(); // 부모 div로의 이벤트 전파를 막습니다.
     setIsShareModalOpen(true);
@@ -185,10 +193,10 @@ const StoreCardInSave = ({
         <GroupSelector
           isOpen={isGroupSelectorOpen}
           topSnapVh={17.8}
-          onClose={() => setIsGroupSelectorOpen(false)}
+          onClose={handleCloseGroupSelector}
         >
           <GroupList
-            onClose={() => setIsGroupSelectorOpen(false)}
+            onClose={handleCloseGroupSelector}
             // 선택된 식당 상태에서 데이터를 가져와 전달
             restaurantName={name}
             restaurantId={restaurantId}

--- a/src/shared/components/storecard/StoreCardInSave.tsx
+++ b/src/shared/components/storecard/StoreCardInSave.tsx
@@ -62,11 +62,10 @@ const StoreCardInSave = ({
         <h2 className="text-[20px] font-bold leading-none text-[#35353F]">{name}</h2>
         {/* 우측 아이콘 버튼들 */}
         <div className="flex gap-[4px]">
-          <button type="button">
+          <button type="button" onClick={handleKeepClick}>
             <img
               src={isKeep ? Save : NotSave}
               alt={isKeep ? 'saved' : 'unsaved'}
-              onClick={handleKeepClick}
               className="h-[25px] w-[25px]"
             />
           </button>

--- a/src/shared/components/storecard/StoreCardInSave.tsx
+++ b/src/shared/components/storecard/StoreCardInSave.tsx
@@ -54,7 +54,7 @@ const StoreCardInSave = ({
 
   // 공유 클릭 시 주소 복사
   const clipLink = () => {
-    navigator.clipboard.writeText(window.location.href);
+    navigator.clipboard.writeText(`${window.location.origin}/detail-info/${restaurantId}`);
     setIsShareModalOpen(false);
     setIsCopiedModalOpen(true);
     setTimeout(() => setIsCopiedModalOpen(false), 1000);


### PR DESCRIPTION
## 📝 작업 내용

- 매장정보가 표시되는 부분들에서 rating 별점이 소수점 1번째 자리까지만 표시되도록 수정하였습니다.
- 기존 CorkageMap 페이지에서 BottomSheet 컴포넌트와 이것으로 전달되는 Children 컴포넌트 내부에서 작동하는 GroupSelector 바텀시트 간의 이중구조로 인한 바텀시트 탑 뷰 이슈를 React Portal 을 이용하여 해결하였습니다.
- GroupSelector 바텀시트와 그 내용물이 이제 DOM 트리의 body 태그 바로 아래 붙기 때문에 이중구조임에도 독립성을 유지할 수 있게됩니다. 이로인해 내부에 중첩된 바텀시트로 작동하더라도 사용자 브라우저 뷰포트 height를 기준으로 동작합니다.

<br/>

## 📢 PR Point

- 

<br/>

## 이미지 첨부


<br/>

## 🔧 다음 할 일

- 다음 할 일을 적어주세요

<br/> 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 카드·상세화면에서 바로 그룹 선택(바텀시트)으로 저장/해제 가능
  * 특정 레스토랑의 북마크(그룹) 상태 조회 기능 추가
  * 공유 기능: 링크 복사 후 복사 완료 확인 모달 제공

* **개선 사항**
  * 그룹 선택 UI를 포탈로 렌더해 표시 안정성 및 SSR 호환성 향상
  * 그룹 색상에 따른 아이콘 매핑 개선
  * 별점 소수점 첫째 자리까지 일관되게 표시
  * 저장/공유 버튼 클릭 시 카드 네비게이션 방지로 오작동 감소
<!-- end of auto-generated comment: release notes by coderabbit.ai -->