### PR TITLE
Fix : 콜키지맵 바텀시트 끌올시 상단 여백공간 하드코딩 useRef로 수정

### DIFF
--- a/src/pages/corkagemap/CorkageMap.tsx
+++ b/src/pages/corkagemap/CorkageMap.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { getBookmarkGroups, createBookmark } from '@/shared/apis/bookmark/bookmark.api';
 import { mapColorToIcon, mapIconToColor } from '@/shared/utils/groupMapper';
@@ -126,18 +126,20 @@ const CorkageMap = () => {
     setIsSheetOpen(true);
   }, []);
 
-  const headerHeightPx = 96;
+  const headerRef = useRef<HTMLDivElement>(null);
+  const [headerHeightPx, setHeaderHeightPx] = useState(96); // 초기 렌더링용 기본값
+  const isMultipinView = sheetView === 'multipin';
+  // 헤더가 화면에 나타날 때(isMultipinView) 실제 높이를 측정하여 업데이트
+  useEffect(() => {
+    if (isMultipinView && headerRef.current) {
+      setHeaderHeightPx(headerRef.current.offsetHeight);
+    }
+  }, [isMultipinView, selectedAreaName]);
+
   const headerVh =
     typeof window !== 'undefined' ? (headerHeightPx / window.innerHeight) * 100 : 11.5;
-  // MyStore 뷰일 때 topSnapVh는 19.8, List일 땐 17.8, 근데 이게 처음에 BottomSheet가 마운트될때 이미 17.8로 마운트되서 바뀌질 않음
-  const currentTopSnapVh =
-    sheetView === 'detail'
-      ? 0 // 화면 상단 5% 정도만 남기고 다 올림 (원하는 만큼 조절)
-      : sheetView === 'multipin'
-        ? headerVh
-        : 17.8;
-  // [편의용] 멀티핀 뷰인지 확인하는 변수
-  const isMultipinView = sheetView === 'multipin';
+
+  const currentTopSnapVh = sheetView === 'detail' ? 0 : sheetView === 'multipin' ? headerVh : 17.8;
 
   const handleSnapToTop = () => {
     // Detail 뷰일 때만 페이지 이동
@@ -225,7 +227,7 @@ const CorkageMap = () => {
         //     <img src={X} alt="X" className="cursor-pointer" onClick={handleSheetClose} />
         //   </div>
         // </div>
-        <div className="absolute z-[102] w-full bg-white px-4">
+        <div ref={headerRef} className="absolute top-0 z-[102] w-full bg-white px-4">
           <Header
             title={selectedAreaName}
             type="back"

--- a/src/pages/corkagemap/CorkageMap.tsx
+++ b/src/pages/corkagemap/CorkageMap.tsx
@@ -131,16 +131,35 @@ const CorkageMap = () => {
   const isMultipinView = sheetView === 'multipin';
   // 헤더가 화면에 나타날 때(isMultipinView) 실제 높이를 측정하여 업데이트
   useEffect(() => {
-    if (isMultipinView && headerRef.current) {
-      setHeaderHeightPx(headerRef.current.offsetHeight);
-    }
+    // 멀티핀 뷰가 아니거나 DOM이 아직 연결되지 않았으면 실행하지 않음
+    if (!isMultipinView || !headerRef.current) return;
+
+    const element = headerRef.current;
+
+    // 높이를 측정해서 state에 업데이트하는 함수
+    const measure = () => setHeaderHeightPx(element.offsetHeight);
+
+    // 마운트 시 최초 1회 측정 실행
+    measure();
+
+    // ResizeObserver: 헤더 요소 자체의 크기 변경 감지
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+
+    // window resize: 브라우저 창 크기 변경(회전 등) 감지
+    window.addEventListener('resize', measure);
+
+    // 클린업 함수: 컴포넌트가 언마운트되거나 의존성이 바뀔 때 이벤트 리스너 해제 (메모리 누수 방지)
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', measure);
+    };
   }, [isMultipinView, selectedAreaName]);
 
   const headerVh =
     typeof window !== 'undefined' ? (headerHeightPx / window.innerHeight) * 100 : 11.5;
 
-  const currentTopSnapVh = sheetView === 'detail' ? 0 : sheetView === 'multipin' ? headerVh : 17.8;
-
+  const currentTopSnapVh = sheetView === 'detail' ? 0 : isMultipinView ? headerVh : 17.8;
   const handleSnapToTop = () => {
     // Detail 뷰일 때만 페이지 이동
     if (sheetView === 'detail' && selectedRestaurantId) {


### PR DESCRIPTION
## 📝 작업 내용

- 아아래 사진 첨부한 부분 기존 96px 이라는 topSnapVh 하드코딩 값으로인해 발생한 문제였고, useRef를 도입하여 해결하였습니다.  

<br/>

## 📢 PR Point

- 

<br/>

## 이미지 첨부

<img width="958" height="1486" alt="image" src="https://github.com/user-attachments/assets/ea031626-c507-47e3-8fe3-969cf363ae94" />

<br/>

## 🔧 다음 할 일

- 다음 QA 사항 진행 (아마 지역필터)

<br/> 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 멀티핀 화면에서 상단 스냅 위치가 실제 헤더 높이에 맞게 계산되도록 개선했습니다.
  * 지역 선택 및 화면 상태 변경 시에도 헤더 높이가 정확히 반영되어 레이아웃 어긋남이 줄었습니다.
  * 헤더 크기 변경 및 창 리사이즈 상황에서도 스냅 계산 값이 자동으로 갱신됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->