### PR TITLE
Fix: 멀티핀 리스트에서 영업시간 해당 요일만 띄우기

### DIFF
--- a/src/shared/components/storecard/StoreCardInMultiPinList.tsx
+++ b/src/shared/components/storecard/StoreCardInMultiPinList.tsx
@@ -152,8 +152,8 @@ const StoreCard = ({
           {/* 영업 상태 */}
           <span className="text-[14px] font-[600] text-[#35353F]">영업중</span>
           {/* 영업 시간 => openingHours */}
-          <span className="max-w-[120px] truncate text-[14px] font-[500] text-[#9FA2AA]">
-            {getTodayOperatingHours(openingHours)}
+          <span className="max-w-[200px] truncate text-[14px] font-[500] text-[#9FA2AA]">
+            {getTodayOperatingHours(openingHours) || '정보 없음'}
           </span>
         </div>
       </div>

--- a/src/shared/components/storecard/StoreCardInMultiPinList.tsx
+++ b/src/shared/components/storecard/StoreCardInMultiPinList.tsx
@@ -13,6 +13,7 @@ import Button from '../common/Button';
 import check from '../../components/detail/assets/check.svg';
 import logo from '@/shared/assets/images/logo.svg';
 import MultiSaveMarker from '../../assets/common/multiSaveMarker.svg';
+import { getTodayOperatingHours } from '@/shared/utils/operatingHours';
 
 // [수정] API 데이터 타입에 맞춰 Props 인터페이스 정의
 interface StoreCardProps {
@@ -152,7 +153,7 @@ const StoreCard = ({
           <span className="text-[14px] font-[600] text-[#35353F]">영업중</span>
           {/* 영업 시간 => openingHours */}
           <span className="max-w-[120px] truncate text-[14px] font-[500] text-[#9FA2AA]">
-            {openingHours}
+            {getTodayOperatingHours(openingHours)}
           </span>
         </div>
       </div>
@@ -197,7 +198,7 @@ const StoreCard = ({
         {/* 기타 행 */}
         <div className="flex w-full items-center">
           <span className="min-w-fit text-[16px] font-[700] text-[#35353F]">기타</span>
-          <span className="ml-[36.5px] line-clamp-2 text-[14px] font-[500] text-[#35353F]">
+          <span className="ml-[36.5px] line-clamp-2 truncate text-[14px] font-[500] text-[#35353F]">
             {corkageOptions?.join(', ')}
           </span>
         </div>


### PR DESCRIPTION
## 📝 작업 내용

- 다중핀 클러스터 클릭시 영업시간이 해당 요일에 맞게 뜨도록 설정

<br/>

## 📢 PR Point

- 

<br/>

## 이미지 첨부
<img width="648" height="1340" alt="image" src="https://github.com/user-attachments/assets/4207b9c2-4c13-40d9-bf56-0a97b2251bee" />
<img width="648" height="1340" alt="image" src="https://github.com/user-attachments/assets/4207b9c2-4c13-40d9-bf56-0a97b2251bee" />


<br/>

## 🔧 다음 할 일

- 다음 할 일을 적어주세요

<br/> 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **기능 개선**
  * 매장 카드에서 영업시간이 현재 기준으로 더 보기 쉽게 표시되도록 개선되었습니다.
  * “기타” 비용 정보의 표시 방식이 조정되어 긴 문구가 더 깔끔하게 보입니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->